### PR TITLE
8.3 rebase xs 20250512

### DIFF
--- a/SOURCES/Fix-GSO-type-for-HW-GRO-packets-on-5750X-chips.patch
+++ b/SOURCES/Fix-GSO-type-for-HW-GRO-packets-on-5750X-chips.patch
@@ -26,12 +26,16 @@ Reviewed-by: Colin Winegarden <colin.winegarden@broadcom.com>
 Reviewed-by: Somnath Kotur <somnath.kotur@broadcom.com>
 Reviewed-by: Kalesh AP <kalesh-anakkur.purayil@broadcom.com>
 Signed-off-by: Michael Chan <michael.chan@broadcom.com>
+---
+ bnxt.c | 12 ++++++------
+ bnxt.h |  3 +++
+ 2 files changed, 9 insertions(+), 6 deletions(-)
 
 diff --git a/bnxt.c b/bnxt.c
-index 6f14f54..4ed0f52 100644
+index ee2303e..951315b 100644
 --- a/bnxt.c
 +++ b/bnxt.c
-@@ -1733,7 +1733,7 @@ static void bnxt_tpa_start(struct bnxt *bp, struct bnxt_rx_ring_info *rxr,
+@@ -2118,7 +2118,7 @@ static void bnxt_tpa_start(struct bnxt *bp, struct bnxt_rx_ring_info *rxr,
  		if (TPA_START_IS_IPV6(tpa_start1))
  			tpa_info->gso_type = SKB_GSO_TCPV6;
  		/* RSS profiles 1 and 3 with extract code 0 for inner 4-tuple */
@@ -40,37 +44,40 @@ index 6f14f54..4ed0f52 100644
  			 TPA_START_HASH_TYPE(tpa_start) == 3)
  			tpa_info->gso_type = SKB_GSO_TCPV6;
  		tpa_info->rss_hash =
-@@ -2522,12 +2522,15 @@ static int bnxt_rx_pkt(struct bnxt *bp, struct bnxt_cp_ring_info *cpr,
- 	}
+@@ -2968,14 +2968,14 @@ make_skb:
+ 		if (cmp_type == CMP_TYPE_RX_L2_V3_CMP) {
+ 			type = bnxt_rss_ext_op(bp, rxcmp);
+ 		} else {
+-			u32 hash_type;
++			u32 itypes = RX_CMP_ITYPES(rxcmp);
  
- 	if (RX_CMP_HASH_VALID(rxcmp)) {
--		u32 hash_type = RX_CMP_HASH_TYPE(rxcmp);
--		enum pkt_hash_types type = PKT_HASH_TYPE_L4;
-+		u32 itypes = RX_CMP_ITYPES(rxcmp);
-+		enum pkt_hash_types type;
- 
--		/* RSS profiles 1 and 3 with extract code 0 for inner 4-tuple */
--		if (hash_type != 1 && hash_type != 3)
-+		if (itypes == RX_CMP_FLAGS_ITYPE_TCP ||
-+		    itypes == RX_CMP_FLAGS_ITYPE_UDP)
-+			type = PKT_HASH_TYPE_L4;
-+		else
- 			type = PKT_HASH_TYPE_L3;
-+
+-			hash_type = RX_CMP_HASH_TYPE(rxcmp);
+ 			/* RSS profiles 1 and 3 with extract code 0 for inner 4-tuple */
+-			if (hash_type != 1 && hash_type != 3)
+-				type = PKT_HASH_TYPE_L3;
+-			else
++			if (itypes == RX_CMP_FLAGS_ITYPE_TCP ||
++			    itypes == RX_CMP_FLAGS_ITYPE_UDP)
+ 				type = PKT_HASH_TYPE_L4;
++			else
++				type = PKT_HASH_TYPE_L3;
+ 		}
  		skb_set_hash(skb, le32_to_cpu(rxcmp->rx_cmp_rss_hash), type);
  	}
- 
 diff --git a/bnxt.h b/bnxt.h
-index 52a50e6..b525ce6 100644
+index b9c06bf..56c2a74 100644
 --- a/bnxt.h
 +++ b/bnxt.h
-@@ -247,6 +247,9 @@ struct rx_cmp {
+@@ -320,6 +320,9 @@ struct rx_cmp {
  	(((le32_to_cpu((rxcmp)->rx_cmp_misc_v1) & RX_CMP_RSS_HASH_TYPE) >>\
  	  RX_CMP_RSS_HASH_TYPE_SHIFT) & RSS_PROFILE_ID_MASK)
  
-+#define RX_CMP_ITYPES(rxcmp)                    \
++#define RX_CMP_ITYPES(rxcmp)					\
 +	(le32_to_cpu((rxcmp)->rx_cmp_len_flags_type) & RX_CMP_FLAGS_ITYPES_MASK)
 +
- #define RX_CMP_V3_HASH_TYPE(rxcmp)					\
- 	(((le32_to_cpu((rxcmp)->rx_cmp_misc_v1) & RX_CMP_V3_RSS_HASH_TYPE) >>\
- 	  RX_CMP_V3_RSS_HASH_TYPE_SHIFT) & RSS_PROFILE_ID_MASK)
+ #define RX_CMP_V3_HASH_TYPE_LEGACY(rxcmp)				\
+ 	((le32_to_cpu((rxcmp)->rx_cmp_misc_v1) & RX_CMP_V3_RSS_EXT_OP_LEGACY) >>\
+ 	 RX_CMP_V3_RSS_EXT_OP_LEGACY_SHIFT)
+-- 
+2.47.1
+

--- a/SOURCES/broadcom-bnxt-en-1.10.2_223.0.183.0.tar.gz
+++ b/SOURCES/broadcom-bnxt-en-1.10.2_223.0.183.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:09705b196a848cb3e219dbf98de4c58825e865ffcd545dde56c17761a11a32b8
-size 1014761

--- a/SOURCES/broadcom-bnxt-en-1.10.3_232.0.155.5.tar.gz
+++ b/SOURCES/broadcom-bnxt-en-1.10.3_232.0.155.5.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6a769bf17db8d1753ede68b8166fee024927cc30514dca51191f52c1ccc9d66
+size 1458484

--- a/SPECS/broadcom-bnxt-en.spec
+++ b/SPECS/broadcom-bnxt-en.spec
@@ -1,8 +1,8 @@
-%global package_speccommit 6d87d73326a77175defc8bf1deeb5cf036bbd493
-%global usver 1.10.2_223.0.183.0
-%global xsver 2
+%global package_speccommit 725c6b5ed804e46a4df8913102d63c611647030b
+%global usver 1.10.3_232.0.155.5
+%global xsver 1
 %global xsrel %{xsver}%{?xscount}%{?xshash}
-%global package_srccommit 1.10.2_223.0.183.0
+%global package_srccommit 1.10.3_232.0.155.5
 %define vendor_name Broadcom
 %define vendor_label broadcom
 %define driver_name bnxt-en
@@ -20,10 +20,10 @@
 
 Summary: %{vendor_name} %{driver_name} device drivers
 Name: %{vendor_label}-%{driver_name}
-Version: 1.10.2_223.0.183.0
+Version: 1.10.3_232.0.155.5
 Release: %{?xsrel}%{?dist}
 License: GPL
-Source0: broadcom-bnxt-en-1.10.2_223.0.183.0.tar.gz
+Source0: broadcom-bnxt-en-1.10.3_232.0.155.5.tar.gz
 Patch0: Fix-GSO-type-for-HW-GRO-packets-on-5750X-chips.patch
 
 BuildRequires: kernel-devel
@@ -69,6 +69,9 @@ find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chm
 %{?_cov_results_package}
 
 %changelog
+* Mon May 12 2025 Deli Zhang <deli.zhang@cloud.com> - 1.10.3_232.0.155.5-1
+- CP-307961: Update broadcom-bnxt-en driver to version 1.10.3_232.0.155.5
+
 * Fri Dec 06 2024 Alex Brett <alex.brett@cloud.com> - 1.10.2_223.0.183.0-2
 - CA-401596: Backport patch to fix GSO type for HW GRO packets on 5750X chips
 


### PR DESCRIPTION
Driver changelog:

```
bnxt: use the NAPI skb allocation cache
bnxt_en: Add tx_resets ring counter
bnxt_en: Display the ring error counters under ethtool -S
bnxt_en: Save ring error counters across reset
bnxt_en: Increment rx_resets counter in bnxt_disable_napi()
bnxt_en: Let the page pool manage the DMA mapping
bnxt_en: Use the unified RX page pool buffers for XDP and non-XDP
bnxt_en: Fix W=stringop-overflow warning in bnxt_dcb.c
bnxt_en: Fix W=1 warning in bnxt_dcb.c from fortify memcpy()
page_pool: split types and declarations from page_pool.h
bnxt_en: Fix max_mtu setting for multi-buf XDP
bnxt_en: Fix page pool logic for page size >= 64K
bnxt: don't handle XDP in netpoll
net: flow_dissector: Use 64bits for used_keys
eth: bnxt: fix warning for define in struct_group
eth: bnxt: fix one of the W=1 warnings about fortified memcpy()
bnxt_en: Share the bar0 address with the RoCE driver
bnxt_en: Update HW interface headers
eth: bnxt: handle invalid Tx completions more gracefully
eth: bnxt: take the bit to set as argument of bnxt_queue_sp_work()
eth: bnxt: move and rename reset helpers
bnxt_en: use dev_consume_skb_any() in bnxt_tx_int
bnxt_en: Implement .set_port / .unset_port UDP tunnel callbacks
bnxt_en: Prevent kernel panic when receiving unexpected PHC_UPDATE event
bnxt_en: Skip firmware fatal error recovery if chip is not accessible
bnxt_en: Query default VLAN before VNIC setup on a VF
bnxt_en: Don't issue AP reset during ethtool's reset operation
bnxt_en: Fix bnxt_hwrm_update_rss_hash_cfg()
eth: bnxt: fix the wake condition
net: remove __skb_frag_set_page()
net: introduce and use skb_frag_fill_page_desc()
bnxt_en: fix free-runnig PHC mode
bnxt_en: Fix a possible NULL pointer dereference in unload path
bnxt: hook NAPIs to page pools
bnxt: use READ_ONCE/WRITE_ONCE for ring indexes
bnxt_en: Allow to set switchdev mode without existing VFs
net: piggy back on the memory barrier in bql when waking queues
bnxt: use new queue try_stop/try_wake macros
RDMA/bnxt_re: Update HW interface headers
bnxt_en: Add missing 200G link speed reporting
bnxt_en: Fix typo in PCI id to device description string mapping
bnxt_en: Fix reporting of test result in ethtool selftest
bnxt: Enforce PTP software freq adjustments only when in non-RTC mode
bnxt: Defer PTP initialization to after querying function caps
bnxt: Change fw_cap to u64 to accommodate more capability bits
bnxt: avoid overflow in bnxt_get_nvram_directory()
bnxt_en: reset PHC frequency in free-running mode
bnxt: Drop redundant pci_enable_pcie_error_reporting()
bnxt_en: Fix the double free during device removal
bnxt_en: Avoid order-5 memory allocation for TPA data
bnxt_en: Fix mqprio and XDP ring checking logic
drivers: net (bnxt_en): turn on XDP features
bnxt_en: Remove runtime interrupt vector allocation
RDMA/bnxt_re: Remove the sriov config callback
bnxt_en: Remove struct bnxt access from RoCE driver
bnxt_en: Use auxiliary bus calls over proprietary calls
bnxt_en: Use direct API instead of indirection
bnxt_en: Remove usage of ulp_id
RDMA/bnxt_re: Use auxiliary driver interface
bnxt_en: Add auxiliary driver support
devlink: remove devlink features
bnxt: Do not read past the end of test names
bnxt: make sure we return pages to the pool
bnxt_en: Fix HDS and jumbo thresholds for RX packets
bnxt_en: Fix first buffer size calculations for XDP multi-buffer
bnxt_en: Fix XDP RX path
bnxt_en: Simplify bnxt_xdp_buff_init()
bnxt_en: fix devlink port registration to netdev
bnxt: Use generic HBH removal helper in tx path
bnxt: report FEC block stats via standard interface
net: devlink: let the core report the driver name instead of the drivers
bnxt_en: Remove debugfs when pci_register_driver failed
ptp: bnxt: convert .adjfreq to .adjfine
bnxt_en: Add a non-real time mode to access NIC clock
bnxt_en: update RSS config using difference algorithm
bnxt_en: refactor VNIC RSS update functions
ethtool: linkstate: add a statistic for PHY down events
bnxt_en: fix potentially incorrect return value for ndo_rx_flow_steer
bnxt_en: Fix possible crash in bnxt_hwrm_set_coal()
bnxt_en: fix the handling of PCIE-AER
bnxt_en: refactor bnxt_cancel_reservations()
net: remove unused ndo_get_devlink_port
net: make drivers to use SET_NETDEV_DEVLINK_PORT to set devlink_port
bnxt_en: check and resize NVRAM UPDATE entry before flashing
bnxt_en: add .get_module_eeprom_by_page() support
bnxt_en: Update firmware interface to 1.10.2.118
bnxt_en: fix memory leak in bnxt_nvm_test()
treewide: use get_random_bytes() when possible
net: drop the weight argument from netif_napi_add
bnxt_en: replace reset with config timestamps
bnxt: prevent skb UAF after handing over to PTP worker
bnxt_en: fix flags to check for supported fw version
net: ethernet: move from strlcpy with unused retval to strscpy
bnxt_en: fix LRO/GRO_HW features in ndo_fix_features callback
bnxt_en: fix NQ resource accounting during vf creation on 57500 chips
bnxt_en: set missing reload flag in devlink features
bnxt_en: Use PAGE_SIZE to init buffer when multi buffer XDP is not in use
bnxt_en: Fix bnxt_refclk_read()
bnxt_en: Fix and simplify XDP transmit path
bnxt_en: fix livepatch query
bnxt_en: Fix bnxt_reinit_after_abort() code path
bnxt_en: reclaim max resources if sriov enable fails
bnxt: Use the bitmap API to allocate bitmaps
net: add skb_[inner_]tcp_all_headers helpers
bnxt: Fix typo in comments
eth: bnxt: make ulp_id unsigned to make GCC 12 happy
bnxt_en: parse and report result field when NVRAM package install fails
bnxt_en: Enable packet timestamping for all RX packets
bnxt_en: Configure ptp filters during bnxt open
bnxt_en: Update firmware interface to 1.10.2.95
bnxt_en: Fix unnecessary dropping of RX packets
bnxt_en: Initiallize bp->ptp_lock first before using it
bnxt_en: Fix possible bnxt_open() failure caused by wrong RFS flag
bnxt: XDP multibuffer enablement
bnxt: support transmit and free of aggregation buffers
bnxt: adding bnxt_xdp_build_skb to build skb from multibuffer xdp_buff
bnxt: add page_pool support for aggregation ring when using xdp
bnxt: change receive ring space parameters
bnxt: set xdp_buff pfmemalloc flag if needed
bnxt: adding bnxt_rx_agg_pages_xdp for aggregated xdp
bnxt: rename bnxt_rx_pages to bnxt_rx_agg_pages_skb
bnxt: refactor bnxt_rx_pages operate on skb_shared_info
bnxt: add flag to denote that an xdp program is currently attached
bnxt: refactor bnxt_rx_xdp to separate xdp_init_buff/xdp_prepare_buff
bnxt_en: Prevent XDP redirect from running when stopping TX queue
bnxt_en: reserve space inside receive page for skb_shared_info
bnxt_en: Synchronize tx when xdp redirects happen on same ring
net: bnxt_ptp: fix compilation error
net: add per-cpu storage and net->core_stats
bnxt_en: Do not destroy health reporters during reset
bnxt_en: Eliminate unintended link toggle during FW reset
bnxt_en: Properly report no pause support on some cards
bnxt_en: introduce initial link state of unknown
bnxt_en: add more error checks to HWRM_NVM_INSTALL_UPDATE
bnxt_en: refactor error handling of HWRM_NVM_INSTALL_UPDATE
bnxt_en: Fix devlink fw_activate
bnxt_en: Increase firmware message response DMA wait time
bnxt_en: Restore the resets_reliable flag in bnxt_open()
bnxt_en: Fix incorrect multicast rx mask setting when not requested
bnxt_en: Fix occasional ethtool -t loopback test failures
bnxt_en: Fix offline ethtool selftest with RDMA enabled
bnxt_en: Fix active FEC reporting to ethtool
bnxt: report header-data split state
```